### PR TITLE
fix: Wrong shebang in nginx template port substitution script

### DIFF
--- a/template-port-env-subst.sh
+++ b/template-port-env-subst.sh
@@ -1,5 +1,4 @@
-#!/bin/sh
-set -e
+#!/bin/bash -e
 
 # This script is automatically run by the nginx server when it starts.
 # See docker-entrypoint.sh in the root of an nginx container.


### PR DESCRIPTION
The script [template-port-env-subst.sh](./template-port-env-subst.sh) uses a `#!/bin/sh` whereas explicit bash features are used for comparison `if [[ ]]`.

During container startup, this cause the error below causing the docker part of the conditional to be unusable.

```shell
/docker-entrypoint.sh: Launching /docker-entrypoint.d/template-port-env-subst.sh
/docker-entrypoint.d/template-port-env-subst.sh: 12: /docker-entrypoint.d/template-port-env-subst.sh: [[: not found
/docker-entrypoint.d/template-port-env-subst.sh: 12: /docker-entrypoint.d/template-port-env-subst.sh: [[: not found
```

This fix enforces a bash shebang to prevent this issue.