### PR TITLE
Remove snyk-container-scan from CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -143,53 +143,12 @@ jobs:
       kosli_api_token: ${{ secrets.KOSLI_API_TOKEN }}
 
 
-  snyk-container-scan:
-    needs: [build-image]
-    runs-on: ubuntu-latest
-    env:
-      IMAGE_NAME:        ${{ needs.build-image.outputs.tagged_image_name }}
-      KOSLI_FINGERPRINT: ${{ needs.build-image.outputs.digest }}
-      SARIF_FILENAME:    snyk.container.scan.json
-    steps:
-      - name: Download docker image
-        uses: cyber-dojo/download-artifact@main
-        with:
-          image_digest: ${{ needs.build-image.outputs.digest }}
-
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Setup Snyk
-        uses: snyk/actions/setup@master
-
-      - name: Run Snyk container scan
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        run:
-          snyk container test ${IMAGE_NAME} 
-            --policy-path=.snyk
-            --sarif 
-            --sarif-file-output="${SARIF_FILENAME}" 
-
-      - name: Setup Kosli CLI
-        if: ${{ github.ref == 'refs/heads/main' }}
-        uses: kosli-dev/setup-cli-action@v2
-        with:
-          version: ${{ vars.KOSLI_CLI_VERSION }}
-
-      - name: Attest evidence to Kosli
-        if: ${{ github.ref == 'refs/heads/main' }}
-        run:
-          kosli attest snyk 
-            --attachments=.snyk          
-            --name=nginx.snyk-container-scan
-            --scan-results="${SARIF_FILENAME}"
-
-
   sdlc-control-gate:
     if: ${{ github.ref == 'refs/heads/main' }}
-    needs: [build-image, pull-request, snyk-container-scan, snyk-code-scan]
+    needs:
+      - build-image
+      - pull-request
+      - snyk-code-scan
     runs-on: ubuntu-latest
     env:
       KOSLI_FINGERPRINT: ${{ needs.build-image.outputs.digest }}

--- a/.kosli.yml
+++ b/.kosli.yml
@@ -7,7 +7,5 @@ trail:
   artifacts:
     - name: nginx
       attestations:
-        - name: snyk-container-scan
-          type: snyk
         - name: snyk-code-scan
           type: snyk


### PR DESCRIPTION
Currently, the snyk-container-scan produces no terminal output, does not create the requested sarif file, and exits with a status code of zero. How rubbish is that! So I am taking the opportunity to move to a new snyk process design inspired by Tore's work. The snyk-scans will now happen only in a dedicated process with its own cron workflow. And I will work towards implementing a policy of making a failed snyk attestation only become non-compliant if it is not fixed in 7 days.