### PR TITLE
Align snyk job inputs with updated reusable workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,10 +103,9 @@ jobs:
     needs: [build-image]
     uses: cyber-dojo/snyk-scanning/.github/workflows/artifact_snyk_test.yml@main
     with:
-      aws_rolename: gh_actions_services
       artifact_name: ${{ needs.build-image.outputs.tagged_image_name }}
-      kosli_flow: ${{vars.KOSLI_FLOW}}
-      kosli_trail: ${{github.sha}}
+      kosli_flow: ${{ env.KOSLI_FLOW }}
+      kosli_trail: ${{ github.sha }}
       kosli_attestation_name: nginx.snyk-container-scan
     secrets:
       snyk_token: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
Remove aws_rolename (no longer accepted) and switch KOSLI_FLOW from vars to env context, matching the updated artifact_snyk_test workflow interface.