### PR TITLE
Replace unsafe if-in-location with try_files + named location

### DIFF
--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -80,27 +80,16 @@ server {
   #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   # For everything else try a static file, otherwise try web.
 
-  location /  {
-    # An HTTP header important enough to have its own Wikipedia entry:
-    # http://en.wikipedia.org/wiki/X-Forwarded-For
+  location / {
+    try_files $uri @web;
+  }
+
+  location @web {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-
-    # Help Rack set the proper protocol (eg https) for doing redirects:
     proxy_set_header X-Forwarded-Proto $scheme;
-
-    # Pass the Host: header from the client right along so redirects
-    # can be set properly within the Rack application
     proxy_set_header Host $http_host;
-
-    # We don't want nginx trying to do something clever with
-    # redirects, we set the Host: header above already.
     proxy_redirect off;
-
-    # Try to serve static files from nginx.
-    if (!-f $request_filename) {
-      proxy_pass http://$web_hostname:${CYBER_DOJO_WEB_PORT};
-      break;
-    }
+    proxy_pass http://$web_hostname:${CYBER_DOJO_WEB_PORT};
   }
 
 }


### PR DESCRIPTION
nginx's `if` inside a location block with proxy_pass is unsafe. Use `try_files $uri @web` with a named `@web` location instead, which is the idiomatic way to serve static files then fall through to a proxy.