### PR TITLE
Fix creator POST routes blocked by GET-only gateway; add rate limiting

### DIFF
--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -6,6 +6,9 @@ map $http_upgrade $connection_upgrade {
   '' close;
 }
 
+limit_req_zone $binary_remote_addr zone=creator_create:1m rate=1r/m;
+limit_req_zone $binary_remote_addr zone=creator_enter:1m  rate=1r/m;
+
 server {
   listen ${CYBER_DOJO_NGINX_PORT};
   server_name localhost;
@@ -44,6 +47,20 @@ server {
   set $differ_hostname ${CYBER_DOJO_DIFFER_HOSTNAME};
   set $saver_hostname ${CYBER_DOJO_SAVER_HOSTNAME};
   set $web_hostname ${CYBER_DOJO_WEB_HOSTNAME};
+
+  location = /creator/create.json {
+    limit_req zone=creator_create burst=3 nodelay;
+    limit_req_status 429;
+    rewrite ^/creator/(.*) /$1 break;
+    proxy_pass http://$creator_hostname:${CYBER_DOJO_CREATOR_PORT};
+  }
+
+  location = /creator/enter.json {
+    limit_req zone=creator_enter burst=3 nodelay;
+    limit_req_status 429;
+    rewrite ^/creator/(.*) /$1 break;
+    proxy_pass http://$creator_hostname:${CYBER_DOJO_CREATOR_PORT};
+  }
 
   location /creator/ {
     rewrite ^/creator/(.*) /$1 break;


### PR DESCRIPTION
PR #109's limit_except GET on /creator/ inadvertently blocked POST /creator/create.json and POST /creator/enter.json, making it impossible to create or join a practice on beta.

Add exact-match location blocks for those two routes before the general /creator/ block, restoring POST access. Rate-limit both at 1r/m per IP with burst=3 nodelay to prevent automated bulk creation.