### PR TITLE
Test rate limiting against the real production image and config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 SHORT_SHA := $(shell git rev-parse HEAD | head -c7)
 IMAGE_NAME := cyberdojo/nginx:${SHORT_SHA}
 
-.PHONY: image snyk-container snyk-code
+.PHONY: image snyk-container snyk-code test
 
 image:
 	${PWD}/bin/build_test.sh
@@ -19,4 +19,7 @@ snyk-code:
 		--sarif \
 		--sarif-file-output=snyk.code.scan.json \
         --policy-path=.snyk
+
+test:
+	${PWD}/bin/run_tests.sh
 

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -Eeu
+
+repo_root() { git rev-parse --show-toplevel; }
+readonly BIN_DIR="$(repo_root)/bin"
+readonly TEST_DIR="$(repo_root)/test"
+readonly COMPOSE_FILE="${TEST_DIR}/docker-compose.yml"
+
+source "${BIN_DIR}/echo_env_vars.sh"
+export $(echo_env_vars)
+
+docker build \
+  --build-arg COMMIT_SHA="${CYBER_DOJO_NGINX_SHA}" \
+  --tag "${CYBER_DOJO_NGINX_IMAGE}:${CYBER_DOJO_NGINX_TAG}" \
+  "$(repo_root)"
+
+docker compose --file "${COMPOSE_FILE}" down --remove-orphans
+
+trap "docker compose --file '${COMPOSE_FILE}' down --remove-orphans" EXIT
+
+docker compose \
+  --file "${COMPOSE_FILE}" \
+  up \
+  --detach \
+  --no-build \
+  --wait \
+  --wait-timeout 60
+
+python3 -m pip install -q -r "${TEST_DIR}/requirements.txt"
+python3 -m pytest "${TEST_DIR}/" -v "$@"

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,0 +1,124 @@
+networks:
+  cyber-dojo:
+    driver: bridge
+    name: cyber-dojo
+
+services:
+
+  nginx:
+    image: ${CYBER_DOJO_NGINX_IMAGE}:${CYBER_DOJO_NGINX_TAG}
+    container_name: test_nginx
+    depends_on:
+      - creator
+      - dashboard
+      - differ
+      - web
+    networks:
+      - cyber-dojo
+    ports: ["8180:80"]
+    restart: "no"
+    user: root
+    init: true
+
+  creator:
+    image: ${CYBER_DOJO_CREATOR_IMAGE}:${CYBER_DOJO_CREATOR_TAG}
+    container_name: test_nginx_creator
+    depends_on:
+      - custom-start-points
+      - exercises-start-points
+      - languages-start-points
+      - saver
+    networks:
+      - cyber-dojo
+    env_file: ["../ports.docker.env"]
+    read_only: true
+    restart: no
+    tmpfs: /tmp
+
+  dashboard:
+    image: ${CYBER_DOJO_DASHBOARD_IMAGE}:${CYBER_DOJO_DASHBOARD_TAG}
+    container_name: test_nginx_dashboard
+    depends_on:
+      - saver
+    networks:
+      - cyber-dojo
+    env_file: ["../ports.docker.env"]
+    read_only: true
+    restart: no
+    tmpfs: /tmp
+
+  differ:
+    image: ${CYBER_DOJO_DIFFER_IMAGE}:${CYBER_DOJO_DIFFER_TAG}
+    container_name: test_nginx_differ
+    depends_on:
+      - saver
+    networks:
+      - cyber-dojo
+    env_file: ["../ports.docker.env"]
+    read_only: true
+    restart: no
+    tmpfs: /tmp
+
+  web:
+    image: ${CYBER_DOJO_WEB_IMAGE}:${CYBER_DOJO_WEB_TAG}
+    container_name: test_nginx_web
+    depends_on:
+      - runner
+      - saver
+    networks:
+      - cyber-dojo
+    env_file: ["../ports.docker.env"]
+    restart: no
+
+  saver:
+    image: ${CYBER_DOJO_SAVER_IMAGE}:${CYBER_DOJO_SAVER_TAG}
+    container_name: test_nginx_saver
+    networks:
+      - cyber-dojo
+    env_file: ["../ports.docker.env"]
+    read_only: true
+    restart: no
+    tmpfs:
+      - /cyber-dojo:uid=19663,gid=65533
+      - /tmp:uid=19663,gid=65533
+
+  runner:
+    image: ${CYBER_DOJO_RUNNER_IMAGE}:${CYBER_DOJO_RUNNER_TAG}
+    container_name: test_nginx_runner
+    networks:
+      - cyber-dojo
+    env_file: ["../ports.docker.env"]
+    read_only: true
+    restart: no
+    tmpfs: /tmp
+    volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+
+  custom-start-points:
+    image: ${CYBER_DOJO_CUSTOM_START_POINTS_IMAGE}:${CYBER_DOJO_CUSTOM_START_POINTS_TAG}
+    container_name: test_nginx_custom_start_points
+    networks:
+      - cyber-dojo
+    env_file: ["../ports.docker.env"]
+    read_only: true
+    restart: no
+    tmpfs: /tmp
+
+  exercises-start-points:
+    image: ${CYBER_DOJO_EXERCISES_START_POINTS_IMAGE}:${CYBER_DOJO_EXERCISES_START_POINTS_TAG}
+    container_name: test_nginx_exercises_start_points
+    networks:
+      - cyber-dojo
+    env_file: ["../ports.docker.env"]
+    read_only: true
+    restart: no
+    tmpfs: /tmp
+
+  languages-start-points:
+    image: ${CYBER_DOJO_LANGUAGES_START_POINTS_IMAGE}:${CYBER_DOJO_LANGUAGES_START_POINTS_TAG}
+    container_name: test_nginx_languages_start_points
+    networks:
+      - cyber-dojo
+    env_file: ["../ports.docker.env"]
+    read_only: true
+    restart: no
+    tmpfs: /tmp

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,0 +1,2 @@
+pytest
+requests

--- a/test/test_image_starts.py
+++ b/test/test_image_starts.py
@@ -1,0 +1,11 @@
+import requests
+
+_NGINX_PORT = 8180
+_BASE_URL = f"http://localhost:{_NGINX_PORT}"
+
+
+def test_c7a2f101():
+    """The production image starts and nginx redirects / to /creator/home."""
+    r = requests.get(f"{_BASE_URL}/", timeout=2, allow_redirects=False)
+    assert r.status_code == 301
+    assert r.headers["Location"].endswith("/creator/home")

--- a/test/test_production_rate_limiting.py
+++ b/test/test_production_rate_limiting.py
@@ -1,0 +1,88 @@
+import requests
+
+_NGINX_PORT = 8180
+_BASE_URL = f"http://localhost:{_NGINX_PORT}"
+
+
+def test_c7a2f102():
+    """Production image: GET /creator/create.json burst=3 exhausts at 5th request."""
+    codes = _statuses("GET", "/creator/create.json", 5)
+    assert codes[-1] == 429
+    assert all(c != 429 for c in codes[:-1])
+
+
+def test_c7a2f106():
+    """Production image: GET /creator/enter.json burst=3 exhausts at 5th request."""
+    codes = _statuses("GET", "/creator/enter.json", 5)
+    assert codes[-1] == 429
+    assert all(c != 429 for c in codes[:-1])
+
+
+def test_c7a2f103():
+    """Production image: POST /kata/fork burst=3 exhausts at 5th request."""
+    codes = _statuses("POST", "/kata/fork", 5)
+    assert codes[-1] == 429
+    assert all(c != 429 for c in codes[:-1])
+
+
+def test_c7a2f107():
+    """Production image: POST /group/fork burst=3 exhausts at 5th request."""
+    codes = _statuses("POST", "/group/fork", 5)
+    assert codes[-1] == 429
+    assert all(c != 429 for c in codes[:-1])
+
+
+def test_c7a2f108():
+    """Production image: POST /kata/file_create burst=3 exhausts at 5th request."""
+    codes = _statuses("POST", "/kata/file_create", 5)
+    assert codes[-1] == 429
+    assert all(c != 429 for c in codes[:-1])
+
+
+def test_c7a2f109():
+    """Production image: POST /kata/file_delete burst=3 exhausts at 5th request."""
+    codes = _statuses("POST", "/kata/file_delete", 5)
+    assert codes[-1] == 429
+    assert all(c != 429 for c in codes[:-1])
+
+
+def test_c7a2f10a():
+    """Production image: POST /kata/file_rename burst=3 exhausts at 5th request."""
+    codes = _statuses("POST", "/kata/file_rename", 5)
+    assert codes[-1] == 429
+    assert all(c != 429 for c in codes[:-1])
+
+
+def test_c7a2f10b():
+    """Production image: POST /kata/file_edit burst=3 exhausts at 5th request."""
+    codes = _statuses("POST", "/kata/file_edit", 5)
+    assert codes[-1] == 429
+    assert all(c != 429 for c in codes[:-1])
+
+
+def test_c7a2f10c():
+    """Production image: POST /kata/option_set burst=3 exhausts at 5th request."""
+    codes = _statuses("POST", "/kata/option_set", 5)
+    assert codes[-1] == 429
+    assert all(c != 429 for c in codes[:-1])
+
+
+def test_c7a2f104():
+    """Production image: POST /kata/run_tests/{id} burst=2 exhausts at 4th request."""
+    codes = _statuses("POST", "/kata/run_tests/a2f104", 4)
+    assert codes[-1] == 429
+    assert all(c != 429 for c in codes[:-1])
+
+
+def test_c7a2f105():
+    """Production image: /kata/run_tests rate limits per URI independently."""
+    codes = _statuses("POST", "/kata/run_tests/b3e209", 4)
+    assert codes[-1] == 429
+    fresh = _statuses("POST", "/kata/run_tests/c4d518", 1)[0]
+    assert fresh != 429
+
+
+def _statuses(method, path, count):
+    """Return list of HTTP status codes for `count` rapid requests."""
+    fn = requests.get if method == "GET" else requests.post
+    return [fn(f"{_BASE_URL}{path}", timeout=5).status_code for _ in range(count)]


### PR DESCRIPTION
Adds a test suite that builds the production nginx image, brings up the full cyber-dojo stack via docker-compose, and verifies that all 10 rate-limiting zones return 429 on burst exhaustion. Tests run via make test -> bin/run_tests.sh.