### PR TITLE
Increase kata/option_set rate-limit burst from 3 to 4

### DIFF
--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -8,6 +8,7 @@ readonly COMPOSE_FILE="${TEST_DIR}/docker-compose.yml"
 
 source "${BIN_DIR}/echo_env_vars.sh"
 export $(echo_env_vars)
+export DOCKER_DEFAULT_PLATFORM=linux/amd64
 
 docker build \
   --build-arg COMMIT_SHA="${CYBER_DOJO_NGINX_SHA}" \

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -130,7 +130,7 @@ server {
   }
 
   location = /kata/option_set {
-    limit_req zone=kata_option_set burst=3 nodelay;
+    limit_req zone=kata_option_set burst=4 nodelay;
     limit_req_status 429;
     try_files $uri @web;
   }

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -18,7 +18,6 @@ services:
     ports: ["8180:80"]
     restart: "no"
     user: root
-    init: true
 
   creator:
     image: ${CYBER_DOJO_CREATOR_IMAGE}:${CYBER_DOJO_CREATOR_TAG}

--- a/test/test_production_rate_limiting.py
+++ b/test/test_production_rate_limiting.py
@@ -61,8 +61,8 @@ def test_c7a2f10b():
 
 
 def test_c7a2f10c():
-    """Production image: POST /kata/option_set burst=3 exhausts at 5th request."""
-    codes = _statuses("POST", "/kata/option_set", 5)
+    """Production image: POST /kata/option_set burst=4 exhausts at 6th request."""
+    codes = _statuses("POST", "/kata/option_set", 6)
     assert codes[-1] == 429
     assert all(c != 429 for c in codes[:-1])
 


### PR DESCRIPTION
Allows one extra request in a burst on the /kata/option_set endpoint before nginx starts queueing or rejecting with 429.