### PR TITLE
Rate-limit creator catch-all GETs to protect start-point services fro…

### DIFF
--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -8,6 +8,7 @@ map $http_upgrade $connection_upgrade {
 
 limit_req_zone $binary_remote_addr zone=creator_create:1m  rate=1r/m;
 limit_req_zone $binary_remote_addr zone=creator_enter:1m   rate=1r/m;
+limit_req_zone $binary_remote_addr zone=creator_choose:1m  rate=10r/m;
 
 limit_req_zone $binary_remote_addr zone=kata_fork:1m       rate=1r/m;
 limit_req_zone $binary_remote_addr zone=group_fork:1m      rate=1r/m;
@@ -75,6 +76,8 @@ server {
 
   location /creator/ {
     rewrite ^/creator/(.*) /$1 break;
+    limit_req zone=creator_choose burst=3 nodelay;
+    limit_req_status 429;
     limit_except GET {
       deny all;
     }

--- a/test/test_production_rate_limiting.py
+++ b/test/test_production_rate_limiting.py
@@ -74,6 +74,13 @@ def test_c7a2f104():
     assert all(c != 429 for c in codes[:-1])
 
 
+def test_c7a2f10d():
+    """Production image: GET /creator/choose_ltf burst=3 exhausts at 5th request."""
+    codes = _statuses("GET", "/creator/choose_ltf", 5)
+    assert codes[-1] == 429
+    assert all(c != 429 for c in codes[:-1])
+
+
 def test_c7a2f105():
     """Production image: /kata/run_tests rate limits per URI independently."""
     codes = _statuses("POST", "/kata/run_tests/b3e209", 4)


### PR DESCRIPTION
…m OOM

The choose_* routes (/creator/choose_problem, /creator/choose_custom_problem, /creator/choose_ltf) call start-point services on every request. A Ruby/Puma upgrade in the start-point base images is causing OOM kills in production. Limiting these GETs to 10r/m burst=3 nodelay at the nginx layer reduces load on start-point services while the Puma issue is resolved.