### PR TITLE
Raise creator catch-all rate limit from 10r/m burst=3 to 60r/m burst=10

### DIFF
--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -8,7 +8,7 @@ map $http_upgrade $connection_upgrade {
 
 limit_req_zone $binary_remote_addr zone=creator_create:1m  rate=1r/m;
 limit_req_zone $binary_remote_addr zone=creator_enter:1m   rate=1r/m;
-limit_req_zone $binary_remote_addr zone=creator_choose:1m  rate=10r/m;
+limit_req_zone $binary_remote_addr zone=creator_choose:1m  rate=60r/m;
 
 limit_req_zone $binary_remote_addr zone=kata_fork:1m       rate=1r/m;
 limit_req_zone $binary_remote_addr zone=group_fork:1m      rate=1r/m;
@@ -76,7 +76,7 @@ server {
 
   location /creator/ {
     rewrite ^/creator/(.*) /$1 break;
-    limit_req zone=creator_choose burst=3 nodelay;
+    limit_req zone=creator_choose burst=10 nodelay;
     limit_req_status 429;
     limit_except GET {
       deny all;

--- a/test/test_production_rate_limiting.py
+++ b/test/test_production_rate_limiting.py
@@ -75,8 +75,8 @@ def test_c7a2f104():
 
 
 def test_c7a2f10d():
-    """Production image: GET /creator/choose_ltf burst=3 exhausts at 5th request."""
-    codes = _statuses("GET", "/creator/choose_ltf", 5)
+    """Production image: GET /creator/choose_ltf burst=10 exhausts at 12th request."""
+    codes = _statuses("GET", "/creator/choose_ltf", 12)
     assert codes[-1] == 429
     assert all(c != 429 for c in codes[:-1])
 


### PR DESCRIPTION
The previous limit was too low for normal browsing: a user clicking through exercise options quickly could exhaust burst=3 after just 4 requests. The limit is per IP, not per kata or session, so shared IPs (schools, offices) would hit it even faster.

60r/m burst=10 allows 11 rapid requests before a 429, which covers realistic browsing patterns while still capping sustained abuse.