### PR TITLE
Add --platform linux/amd64 to docker build in build_test.sh

### DIFF
--- a/.github/workflows/force-ci-run
+++ b/.github/workflows/force-ci-run
@@ -1,2 +1,2 @@
 Edit this file for a quick way to force a CI run
-131
+132

--- a/bin/build_test.sh
+++ b/bin/build_test.sh
@@ -32,6 +32,7 @@ build_tagged_image()
 {
   echo; echo Building tagged image
   docker build \
+    --platform linux/amd64 \
     --no-cache \
     --build-arg COMMIT_SHA="${CYBER_DOJO_NGINX_SHA}" \
     --tag "$(tagged_image_name)" \


### PR DESCRIPTION
Ensures the image is built for the correct architecture on Apple Silicon hosts, preventing platform mismatch errors at test time.