### PR TITLE
Raise kata_file_edit burst limit from 3 to 10

### DIFF
--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -127,7 +127,7 @@ server {
   }
 
   location = /kata/file_edit {
-    limit_req zone=kata_file_edit burst=3 nodelay;
+    limit_req zone=kata_file_edit burst=10 nodelay;
     limit_req_status 429;
     try_files $uri @web;
   }

--- a/test/test_production_rate_limiting.py
+++ b/test/test_production_rate_limiting.py
@@ -54,8 +54,8 @@ def test_c7a2f10a():
 
 
 def test_c7a2f10b():
-    """Production image: POST /kata/file_edit burst=3 exhausts at 5th request."""
-    codes = _statuses("POST", "/kata/file_edit", 5)
+    """Production image: POST /kata/file_edit burst=10 exhausts at 12th request."""
+    codes = _statuses("POST", "/kata/file_edit", 12)
     assert codes[-1] == 429
     assert all(c != 429 for c in codes[:-1])
 


### PR DESCRIPTION
The endpoint fires on file selection, not only on actual edits, so the previous burst of 3 was too low and rate-limited normal navigation.