### PR TITLE
Switch to using the Kosli 'tf' tooling

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -156,16 +156,16 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    uses: fivexl/gh-workflow-tf-plan-apply/.github/workflows/base.yml@v0.0.28
+      pull-requests: read
+    uses: kosli-dev/tf/.github/workflows/apply.yml@main
     with:
-      aws_region: ${{ needs.setup.outputs.aws_region }}
+      aws_region: eu-central-1
       aws_role_arn: arn:aws:iam::${{ needs.setup.outputs.aws_account_id_beta }}:role/${{ needs.setup.outputs.gh_actions_iam_role_name }}
-      aws_default_region: ${{ needs.setup.outputs.aws_region }}
-      aws_role_duration: 900
+      environment: beta
       working_directory: deployment/terraform/
-      tf_apply: true
       tf_version: v1.9.1
-      tf_additional_env_vars: '{"TF_VAR_TAGGED_IMAGE": "${{ needs.build-image.outputs.tagged_image_name }}@sha256:${{ needs.build-image.outputs.digest }}"}'
+      tf_vars: |
+        TF_VAR_TAGGED_IMAGE=${{ needs.build-image.outputs.tagged_image_name }}@sha256:${{ needs.build-image.outputs.digest }}
 
 
 # Deployment to aws-prod Environment is done with a Promotion workflow.


### PR DESCRIPTION
In order to leverage the new Kosli drift detection, we need to migrate to using the Kosli `tf` workflows.