### PR TITLE
Force rebuild to pick up libexpat 2.8.2-r0 (fixes CVE-2026-50219)

### DIFF
--- a/.github/workflows/force-ci-run
+++ b/.github/workflows/force-ci-run
@@ -1,2 +1,2 @@
 Edit this file for a quick way to force a CI run
-142
+143


### PR DESCRIPTION
  Snyk flagged SNYK-ALPINE323-EXPAT-17675120 (CVE-2026-50219), a
  use-after-free in libexpat, in the deployed nginx image. The pinned
  base ships libexpat-2.7.5-r0, below the 2.8.2-r0 fix now in the Alpine
  3.23 repos. The Dockerfile's existing `apk upgrade` already pulls
  2.8.2-r0 (verified), so no Dockerfile change is needed -- a fresh build
  resolves the finding and re-attests a clean container scan to Kosli.