### PR TITLE
Gate test containers on runner health and quiet urllib3 warning

### DIFF
--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -23,10 +23,18 @@ services:
     image: ${CYBER_DOJO_CREATOR_IMAGE}:${CYBER_DOJO_CREATOR_TAG}
     container_name: test_nginx_creator
     depends_on:
-      - custom-start-points
-      - exercises-start-points
-      - languages-start-points
-      - saver
+      custom-start-points:
+        condition: service_started
+      exercises-start-points:
+        condition: service_started
+      languages-start-points:
+        condition: service_started
+      saver:
+        condition: service_started
+      # creator calls runner (prober, pull_image); wait until it is healthy
+      # so creator does not race a not-yet-listening runner on startup.
+      runner:
+        condition: service_healthy
     networks:
       - cyber-dojo
     env_file: ["../ports.docker.env"]
@@ -62,8 +70,10 @@ services:
     image: ${CYBER_DOJO_WEB_IMAGE}:${CYBER_DOJO_WEB_TAG}
     container_name: test_nginx_web
     depends_on:
-      - runner
-      - saver
+      runner:
+        condition: service_healthy
+      saver:
+        condition: service_started
     networks:
       - cyber-dojo
     env_file: ["../ports.docker.env"]

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -1,0 +1,12 @@
+[pytest]
+# The test runner uses the host's python3. On macOS that is the system
+# Python, whose ssl module is built against LibreSSL; urllib3 v2 (pulled in
+# by requests) warns at import that it only supports OpenSSL 1.1.1+. The
+# tests only talk to http://localhost (no TLS), so the warning is noise.
+#
+# This MUST be matched by message, not by the category
+# urllib3.exceptions.NotOpenSSLWarning: a category filter makes Python import
+# urllib3 to resolve the class, and that import is what emits the warning, so
+# the filter is installed too late. Matching the message needs no import.
+filterwarnings =
+    ignore:urllib3 v2 only supports OpenSSL 1.1.1:Warning


### PR DESCRIPTION
  test/docker-compose.yml: creator and web call runner, so wait for
  runner to be healthy (condition: service_healthy) instead of merely
  started, removing the startup race that logged runner:4597 connection
  refused.

  test/pytest.ini: ignore urllib3's NotOpenSSLWarning (host macOS Python
  is built against LibreSSL; tests use http only). Matched by message,
  not category, because a category filter would import urllib3 and emit
  the warning before the filter installs.

  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>